### PR TITLE
➕ adding side options

### DIFF
--- a/src/Onborda.tsx
+++ b/src/Onborda.tsx
@@ -214,6 +214,52 @@ const Onborda: React.FC<OnbordaProps> = ({
           top: "50%",
           marginLeft: "25px",
         };
+      case "top-left":
+        return {
+          bottom: "100%",
+          marginBottom: "25px",
+        };
+      case "top-right":
+        return {
+          right: 0,
+          bottom: "100%",
+          marginBottom: "25px",
+        };
+      case "bottom-left":
+        return {
+          top: "100%",
+          marginTop: "25px",
+        };
+      case "bottom-right":
+        return {
+          right: 0,
+          top: "100%",
+          marginTop: "25px",
+        };
+      case "right-bottom":
+        return {
+          left: "100%",
+          bottom: 0,
+          marginLeft: "25px",
+        };
+      case "right-top":
+        return {
+          left: "100%",
+          top: 0,
+          marginLeft: "25px",
+        };
+      case "left-bottom":
+        return {
+          right: "100%",
+          bottom: 0,
+          marginRight: "25px",
+        };
+      case "left-top":
+        return {
+          right: "100%",
+          top: 0,
+          marginRight: "25px",
+        };
       default:
         return {}; // Default case if no side is specified
     }
@@ -246,6 +292,54 @@ const Onborda: React.FC<OnbordaProps> = ({
           transform: `translate(0, -50%) rotate(0deg)`,
           top: "50%",
           right: "-23px",
+        };
+      case "top-left":
+        return {
+          transform: `rotate(90deg)`,
+          left: "10px",
+          bottom: "-23px",
+        };
+      case "top-right":
+        return {
+          transform: `rotate(90deg)`,
+          right: "10px",
+          bottom: "-23px",
+        };
+      case "bottom-left":
+        return {
+          transform: `rotate(270deg)`,
+          left: "10px",
+          top: "-23px",
+        };
+      case "bottom-right":
+        return {
+          transform: `rotate(270deg)`,
+          right: "10px",
+          top: "-23px",
+        };
+      case "right-bottom":
+        return {
+          transform: `rotate(180deg)`,
+          left: "-23px",
+          bottom: "10px",
+        };
+      case "right-top":
+        return {
+          transform: `rotate(180deg)`,
+          left: "-23px",
+          top: "10px",
+        };
+      case "left-bottom":
+        return {
+          transform: `rotate(0deg)`,
+          right: "-23px",
+          bottom: "10px",
+        };
+      case "left-top":
+        return {
+          transform: `rotate(0deg)`,
+          right: "-23px",
+          top: "10px",
         };
       default:
         return {}; // Default case if no side is specified

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,7 +15,7 @@ export interface Step {
   content: React.ReactNode;
   selector: string;
   // Options
-  side?: "top" | "bottom" | "left" | "right";
+  side?: "top" | "bottom" | "left" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right" | "left-top" | "left-bottom" | "right-top" | "right-bottom";
   showControls?: boolean;
   pointerPadding?: number;
   pointerRadius?: number;


### PR DESCRIPTION
# Add more side options to prevent screen overflow #9
These changes allow developers to have more control over the location of the tooltip card. It's so useful to avoid the screen edges.

### How does it work?
That so simple, developers can add new side options for each step choosing the position to render the tooltip card.
e.g:
```typescript
const steps: Step[] = [
    {
        icon: '🎉',
        title: 'Use our new side options',
        selector: '[data-onborda="step1"]',
        side: 'right-bottom', // <-- THERE IS A NEW OPTION
        content: (
            <p>
                😎 This tooltip looks so great!
            </p>
        ),
        pointerPadding: -1,
        pointerRadius: 6,
    },
```

### What are the new side options?
* `right-bottom`
* `right-top`
* `bottom-right`
* `bottom-left`
* `left-top`
* `left-bottom`
* `top-left`
* `top-right`

e.g:
![ezgif-7-f791cd04bd](https://github.com/uixmat/onborda/assets/24913036/05ea12e9-6841-494a-807d-4332b5bf76df)

### Conclusions
I hope it can be useful for someone who has problems with screen edges. This is my approach to fix it as soon as possible.
In my opinion, it's easy to use, no learning curve, and looks fantastic. Maybe in the future it can be automatic.

#### Made with ❤️ by @sejoalfaro